### PR TITLE
Bump Spark version to 3.3.3 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.10-bullseye as spark-base
 
-ARG SPARK_VERSION=3.3.2
+ARG SPARK_VERSION=3.3.3
 
 # Install tools required by the OS
 RUN apt-get update && \


### PR DESCRIPTION
The latest download of Spark is for version 3.3.3. Spark version 3.3.2 was archived and the download link is defect now.