### PR TITLE
Added the execute permission for the sh file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,5 +54,6 @@ ENV PYTHONPATH=$SPARK_HOME/python/:$PYTHONPATH
 
 # Copy appropriate entrypoint script
 COPY entrypoint.sh .
+RUN chmod +x entrypoint.sh
 
 ENTRYPOINT ["./entrypoint.sh"]


### PR DESCRIPTION
**Problem Statement**
The entrypoint.sh script does not have the necessary execute permission.

**Error Detail**
Creating da-spark-master ... error
ERROR: for spark-master  Cannot start service spark-master: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "./entrypoint.sh": permission denied: unknown
ERROR: Encountered errors while bringing up the project.
make: *** [run] Error 1

**Proposed Solution**
The error indicates that the entrypoint.sh script does not have the necessary execute permissions. To resolve this issue, we need to ensure that the entrypoint.sh script is executable.  We can do this by adding the following command in Dockerfile:
`chmod +x entrypoint.sh`

**Result**
This command changes the permissions of the entrypoint.sh file to make it executable.  

**Run**
After setting the execute permissions, rebuild and run the Docker containers:
```
make build
make run
```
This should resolve the issue and allow the containers to start successfully.